### PR TITLE
remove tolerance param

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ Send a GET request with the following parameters in the query string
 - account
 - email
 - frequency (seconds)
-- tolerance (seconds)
 
 Test with
-`curl -v "localhost:8080/?cronname=mycronjob&account=myaccount&email=myemail@gmail.com&frequency=3600&tolerance=120"`
+`curl -v "localhost:8080/?cronname=mycronjob&account=myaccount&email=myemail@gmail.com&frequency=3600"`
 
 Append to an existing crontab entry with:
-`&& curl -v "localhost:8080/?cronname=mycronjob&account=myaccount&email=myemail@gmail.com&frequency=3600&tolerance=120"`
+`&& curl -v "localhost:8080/?cronname=mycronjob&account=myaccount&email=myemail@gmail.com&frequency=3600"`
 
 
-The above examples will notify the server every hour with a tolerance of 2 minutes. If the job does not check in within 2 hours and 2 minutes, an email alert is sent. Future notifications are suppressed until the job checks in again.
+The above examples will notify the server to expect a notification every hour. If the job does not check in within 1 hour, an email alert is sent. Future notifications are suppressed until the job checks in again.
 
 ## Sizing
 A single Google Compute Engine f1-micro instance has been proven to handle 50,000 jobs
@@ -37,7 +36,7 @@ recommended, however, this ability is not yet available. Please see the TODO sec
 
 ### Postgresql must be installed and listening on localhost
 - `CREATE DATABASE gocron;`
-- `CREATE TABLE gocron(cronName varchar, account varchar, email varchar, ipaddress varchar, frequency varchar, tolerance int, lastruntime varchar, alerted boolean, PRIMARY KEY(cronname, account));`
+- `CREATE TABLE gocron(cronName varchar, account varchar, email varchar, ipaddress varchar, frequency varchar, lastruntime varchar, alerted boolean, PRIMARY KEY(cronname, account));`
 - `CREATE USER gocron WITH PASSWORD 'password';`
 - `GRANT ALL PRIVILEGES ON gocron TO gocron;`
 

--- a/src/backend.go
+++ b/src/backend.go
@@ -45,7 +45,6 @@ func checkCronStatus() {
                         &c.email,
                         &c.ipaddress,
                         &c.frequency,
-                        &c.tolerance,
                         &c.lastruntime,
                         &c.alerted)
 
@@ -53,12 +52,10 @@ func checkCronStatus() {
             var currentTime = int(time.Now().Unix())
             var lastRunTime, _ = strconv.Atoi(c.lastruntime)
             var frequency, _ = strconv.Atoi(c.frequency)
-            var tolerance, _ = strconv.Atoi(c.tolerance)
-            var maxTime = frequency + tolerance
 
 
             // If not checked in on time
-            if (currentTime - lastRunTime) > maxTime {
+            if (currentTime - lastRunTime) > frequency {
                   subject = c.cronname + ": " + c.account + " failed to check in" + "\n"
                   message = "The cronjob " + c.cronname + " for account " + c.account + " has not checked in on time"
 
@@ -79,7 +76,7 @@ func checkCronStatus() {
 
 
             // If checked in on time but previously not (alerted == true)
-            } else if ((currentTime - lastRunTime) < maxTime) && c.alerted == true {
+            } else if ((currentTime - lastRunTime) < frequency) && c.alerted == true {
                   _, err = db.Exec("UPDATE gocron SET alerted = false " +
                               "WHERE cronname = '" + c.cronname + "' AND account = '" + c.account + "';")
                   if err != nil {

--- a/src/gocron.go
+++ b/src/gocron.go
@@ -29,7 +29,6 @@ type Cron struct {
       email       string   // Address to send alerts to
       ipaddress   string   // Source IP address
       frequency   string   // How often a job should check in
-      tolerance   string   // Additional time before an alert is thrown
       lastruntime string   // Unix timestamp
       alerted     bool     // set to true if an alert has already been thrown
 }
@@ -38,7 +37,7 @@ type Cron struct {
 
 // Global variables
 var config Config             // Stores configuration values in a Cron struct
-var version string = "1.0.5"  // Current version
+var version string = "1.0.6"  // Current version
 var verbose bool = false      // Flag enabling / disabling verbosity
 
 
@@ -106,7 +105,6 @@ func cronStatus(w http.ResponseWriter, req *http.Request) {
             cronJob.account = req.URL.Query().Get("account")
             cronJob.email = req.URL.Query().Get("email")
             cronJob.frequency = req.URL.Query().Get("frequency")
-            cronJob.tolerance = req.URL.Query().Get("tolerance")
             cronJob.lastruntime = strconv.Itoa(currentTime)
             cronJob.ipaddress = socket[0]
 
@@ -117,7 +115,6 @@ func cronStatus(w http.ResponseWriter, req *http.Request) {
             cronJob.account = ""
             cronJob.email = ""
             cronJob.frequency = ""
-            cronJob.tolerance = ""
             cronJob.lastruntime = strconv.Itoa(currentTime)
             cronJob.ipaddress = socket[0]
 
@@ -143,20 +140,18 @@ func cronStatus(w http.ResponseWriter, req *http.Request) {
 func updateDatabase(c Cron) {
       // Build the database query
       var query string
-      query = "INSERT INTO gocron (cronname, account, email, ipaddress, frequency, tolerance, lastruntime, alerted) VALUES ('" +
+      query = "INSERT INTO gocron (cronname, account, email, ipaddress, frequency, lastruntime, alerted) VALUES ('" +
              c.cronname + "','" +
              c.account + "','" +
              c.email + "','" +
              c.ipaddress + "','" +
              c.frequency + "','" +
-             c.tolerance + "','" +
              c.lastruntime + "','" +
              "false" + "') " +
              "ON CONFLICT (cronname, account) DO UPDATE " +
              "SET email = " + "'" + c.email + "'," +
              "ipaddress = " + "'" + c.ipaddress + "'," +
              "frequency = " + "'" + c.frequency + "'," +
-             "tolerance = " + "'" + c.tolerance + "'," +
              "lastruntime = " + "'" + c.lastruntime + "'" +
              ";"
 

--- a/src/helper.go
+++ b/src/helper.go
@@ -38,7 +38,7 @@ func validateArgs(c Cron) bool {
             if valid == true {
                   cronLog("Parameters from " + c.ipaddress + " passed validation")
                   return true
-                  
+
             } else {
                   cronLog("Parameters from " + c.ipaddress + " failed validation!")
                   return false
@@ -69,9 +69,6 @@ func checkLength(c Cron) bool {
             return false
 
       } else if len(c.lastruntime) == 0 {
-            return false
-
-      } else if len(c.tolerance) == 0 {
             return false
 
       } else {


### PR DESCRIPTION
Tolerance is somewhat pointless. No longer used, instead use a large frequency time. 

Example: */5 * * * * curl <args>?frequency=600

The command runs every five minutes but will not trigger an alert until it has missed for 10 minutes. 