### PR TITLE
Use flags package for frontend

### DIFF
--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -13,7 +13,7 @@ const (
       version string     = "2.0.8"
       libVersion string  = gocronlib.Version
 
-      socket string      = ":8080"
+      port string        = "8080"
       errorResp string   = "Internal Server Error"
       contentType string = "plain/text"
 )
@@ -25,7 +25,6 @@ var (
 
 
 func main() {
-
       flag.BoolVar(&getVersion, "version", false, "Get the version and then exit")
       flag.BoolVar(&verbose, "verbose", false, "Enable verbose output")
       flag.Parse()
@@ -36,16 +35,21 @@ func main() {
             return
       }
 
+      if verbose == true {
+            println("Verbose mode enabled")
+            println("gocron-front version: " + version)
+            println("gocronlib version: " + libVersion)
+            println("Starting web server on port: " + port)
+      }
+
       // Start the web server
       http.HandleFunc("/", cronStatus)
-      http.ListenAndServe(socket, nil)
-
+      http.ListenAndServe(":" + port, nil)
 }
 
 
 // Validate the request and then pass to updateDatabase()
 func cronStatus(resp http.ResponseWriter, req *http.Request) {
-
       var (
             currentTime int = int(time.Now().Unix())
             socket = strings.Split(req.RemoteAddr, ":")

--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -12,9 +12,7 @@ import (
 const (
       version string     = "2.0.8"
       libVersion string  = gocronlib.Version
-)
 
-const (
       socket string      = ":8080"
       errorResp string   = "Internal Server Error"
       contentType string = "plain/text"

--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -19,8 +19,8 @@ const (
 )
 
 var (
-      verbose bool    = false  // Flag enabling / disabling verbosity
-      getVersion bool = false  // Flag
+      verbose bool     // Flag enabling / disabling verbosity
+      getVersion bool  // Flag
 )
 
 

--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -1,7 +1,7 @@
 package main
 import (
-      "os"
       "time"
+      "flag"
       "strings"
       "strconv"
       "net/http"
@@ -9,45 +9,51 @@ import (
 )
 
 
-const version string     = "2.0.7"
-const libVersion string  = gocronlib.Version
+const (
+      version string     = "2.0.8"
+      libVersion string  = gocronlib.Version
+)
 
-const socket string      = ":8080"
-const errorResp string   = "Internal Server Error"
-const contentType string = "plain/text"
+const (
+      socket string      = ":8080"
+      errorResp string   = "Internal Server Error"
+      contentType string = "plain/text"
+)
 
-var verbose bool  = false       // Flag enabling / disabling verbosity
-var args []string = os.Args     // Command line arguments
+var (
+      verbose bool    = false  // Flag enabling / disabling verbosity
+      getVersion bool = false  // Flag
+)
 
 
 func main() {
-      // Parse arguments
-      if len(os.Args) > 1 {
-            // Return the current version
-            if strings.Contains(args[1], "--version") {
-                  println("gocron-front version: " + version)
-                  println("gocronlib version: " + libVersion)
-                  os.Exit(0)
-            }
-            // When enabled, all logging will also print to screen
-            if strings.Contains(args[1], "--verbose") {
-                  verbose = true
-                  gocronlib.CronLog("gocron started with --verbose.", verbose)
-            }
+
+      flag.BoolVar(&getVersion, "version", false, "Get the version and then exit")
+      flag.BoolVar(&verbose, "verbose", false, "Enable verbose output")
+      flag.Parse()
+
+      if getVersion == true {
+            println("gocron-front version: " + version)
+            println("gocronlib version: " + libVersion)
+            return
       }
 
       // Start the web server
       http.HandleFunc("/", cronStatus)
       http.ListenAndServe(socket, nil)
+
 }
 
 
 // Validate the request and then pass to updateDatabase()
 func cronStatus(resp http.ResponseWriter, req *http.Request) {
-      var currentTime int = int(time.Now().Unix())
-      var socket = strings.Split(req.RemoteAddr, ":")
-      var c gocronlib.Cron
-      var method string = ""
+
+      var (
+            currentTime int = int(time.Now().Unix())
+            socket = strings.Split(req.RemoteAddr, ":")
+            c gocronlib.Cron
+            method string = ""
+      )
 
       switch req.Method {
       case "GET":
@@ -114,9 +120,10 @@ func returnNotFound(resp http.ResponseWriter) {
 
 
 func updateDatabase(c gocronlib.Cron) bool {
-      // Build the database query
-      var query string
-      var result bool
+      var (
+            query string
+            result bool
+      )
 
       // Insert and update if already exist
       query = "INSERT INTO gocron " +

--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -153,15 +153,13 @@ func updateDatabase(c gocronlib.Cron) bool {
 
 // Function validates SQL variables
 func validateParams(c gocronlib.Cron) bool {
-      // Flag determines the return value
-      var valid bool = false
 
-      // Perform validation of parameters
+      var valid bool = false  // Flag determines the return value
+
       if checkLength(c) == true {
             valid = true
       }
 
-      // Log result if verbose is enabled
       if verbose == true {
             if valid == true {
                   gocronlib.CronLog("Parameters from " + c.Ipaddress + " passed validation", verbose)
@@ -173,7 +171,6 @@ func validateParams(c gocronlib.Cron) bool {
             }
       }
 
-      // Return true or false
       return valid
 }
 


### PR DESCRIPTION
Instead of using the os package to parse flags, we are now using the flags package. Other misc updates. 

```
-verbose  // enables verbose output
-version  // returns the working version
```