### PR TITLE
Issue 37 - Marking row as alerted even if alert fails - fixed

### DIFF
--- a/src/backend/gocron-back.go
+++ b/src/backend/gocron-back.go
@@ -92,24 +92,22 @@ func checkCronStatus() {
             // If job not checked in on time
             if (currentTime - lastRunTime) > frequency {
 
-                  // Mark row as alerted if not already true
+                  // If not already alerted
                   if cron.Alerted != true {
-                        query = "UPDATE gocron SET alerted = true " +
-                                "WHERE cronname = '" + cron.Cronname + "' AND account = '" + cron.Account + "';"
-
-                        // Perform the query
-                        rows, result = gocronlib.QueryDatabase(query, verbose)
-                        defer rows.Close()
-                        if result == false {
-                              gocronlib.CronLog(updateFail, verbose)
-
-                        }
-
-                        // Trigger alert
                         subject = cron.Cronname + ": " + cron.Account + " failed to check in" + "\n"
                         message = "The cronjob " + cron.Cronname + " for account " + cron.Account + " has not checked in on time"
-                        alert(cron, subject, message)
 
+                        // Only update database if alert sent successful
+                        if alert(cron, subject, message) == true {
+                              query = "UPDATE gocron SET alerted = true " +
+                                      "WHERE cronname = '" + cron.Cronname + "' AND account = '" + cron.Account + "';"
+
+                              rows, result = gocronlib.QueryDatabase(query, verbose)
+                              defer rows.Close()
+                              if result == false {
+                                    gocronlib.CronLog(updateFail, verbose)
+                              }
+                        }
 
 
                   // If 'alerted' already  true
@@ -169,7 +167,7 @@ func alert(cron gocronlib.Cron, subject string, message string) bool {
             return false
       }
 
-      // Alert sent 
+      // Alert sent
       gocronlib.CronLog("Alert for " + cron.Cronname + " sent to " + recipient, verbose)
       return true
 }

--- a/src/backend/gocron-back.go
+++ b/src/backend/gocron-back.go
@@ -148,24 +148,28 @@ func checkCronStatus() {
 
 func alert(cron gocronlib.Cron, subject string, message string) bool {
 
+      // Emmediatly log the alert
       gocronlib.CronLog(subject, verbose)
 
-      var recipient string = cron.Email
-      var port, _ = strconv.Atoi(config.Smtpport)
-      var d = gomail.NewDialer(config.Smtpserver, port, config.Smtpaddress, config.Smtppassword)
-      var m = gomail.NewMessage()
+      var (
+            recipient string = cron.Email
+            port, _ = strconv.Atoi(config.Smtpport)
+            d = gomail.NewDialer(config.Smtpserver, port, config.Smtpaddress, config.Smtppassword)
+            m = gomail.NewMessage()
+      )
 
       m.SetHeader("From", config.Smtpaddress)
       m.SetHeader("To", recipient)
       m.SetHeader("Subject", subject)
       m.SetBody("text/html", message)
 
+      // Failed to send alert
       if err := d.DialAndSend(m); err != nil {
             gocronlib.CheckError(err, verbose)
             return false
       }
 
+      // Alert sent 
       gocronlib.CronLog("Alert for " + cron.Cronname + " sent to " + recipient, verbose)
-
       return true
 }

--- a/src/backend/gocron-back.go
+++ b/src/backend/gocron-back.go
@@ -11,7 +11,7 @@ import (
 
 
 const (
-      version string    = "2.0.8"
+      version string    = "2.0.9"
       libVersion string = gocronlib.Version
 )
 
@@ -105,11 +105,11 @@ func checkCronStatus() {
 
                         }
 
-                        // Query was successful - Trigger alert
+                        // Trigger alert
                         subject = cron.Cronname + ": " + cron.Account + " failed to check in" + "\n"
                         message = "The cronjob " + cron.Cronname + " for account " + cron.Account + " has not checked in on time"
                         alert(cron, subject, message)
-                        gocronlib.CronLog(subject, verbose)
+
 
 
                   // If 'alerted' already  true
@@ -135,7 +135,6 @@ func checkCronStatus() {
                   subject = cron.Cronname + ": " + cron.Account + " is back online" + "\n"
                   message = "The cronjob " + cron.Cronname + " for account " + cron.Account + " is back online"
                   alert(cron, subject, message)
-                  gocronlib.CronLog(subject, verbose)
 
 
             } else {
@@ -147,7 +146,9 @@ func checkCronStatus() {
 }
 
 
-func alert(cron gocronlib.Cron, subject string, message string) {
+func alert(cron gocronlib.Cron, subject string, message string) bool {
+
+      gocronlib.CronLog(subject, verbose)
 
       var recipient string = cron.Email
       var port, _ = strconv.Atoi(config.Smtpport)
@@ -161,7 +162,10 @@ func alert(cron gocronlib.Cron, subject string, message string) {
 
       if err := d.DialAndSend(m); err != nil {
             gocronlib.CheckError(err, verbose)
+            return false
       }
 
       gocronlib.CronLog("Alert for " + cron.Cronname + " sent to " + recipient, verbose)
+
+      return true
 }


### PR DESCRIPTION
Resolves https://github.com/jsirianni/gocron/issues/37

No longer are rows marked as `alerted = true` if the actual alert fails to send. This is only true for sending alerts notifying of failed to check in systems. A system that comes back online will be marked `alerted = false` even if the email notifying of this fails. 

