### PR TITLE
Implement POST support

### DIFF
--- a/src/backend/gocron-back.go
+++ b/src/backend/gocron-back.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	version    string = "3.0.4"
+	version    string = "3.0.6"
 	libVersion string = gocronlib.Version
 )
 

--- a/src/frontend/gocron-front.go
+++ b/src/frontend/gocron-front.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version     string = "3.0.4"
+	version     string = "3.0.6"
 	libVersion  string = gocronlib.Version
 	errorResp   string = "Internal Server Error"
 	contentType string = "plain/text"

--- a/src/gocronlib/gocronlib.go
+++ b/src/gocronlib/gocronlib.go
@@ -10,7 +10,7 @@ import (
 )
 
 
-const Version string  = "2.0.4"
+const Version string  = "2.0.5"
 
 const (
       sslmode  string = "disable"   // Disable or enable ssl
@@ -36,14 +36,14 @@ type Config struct {
 
 
 type Cron struct {
-      Cronname    string   // Name of the cronjob
-      Account     string   // Account the job belongs to
-      Email       string   // Address to send alerts to
+      Cronname    string `json:cronname`  // Name of the cronjob
+      Account     string `json:account`   // Account the job belongs to
+      Email       string `json:email`     // Address to send alerts to
+      Frequency   int    `json:frequency` // How often a job should check in
+      Site        bool   `json:site`      // Set true if service is a site (Example: Network gateway)
       Ipaddress   string   // Source IP address
-      Frequency   int      // How often a job should check in
       Lastruntime int      // Unix timestamp
       Alerted     bool     // set to true if an alert has already been thrown
-      Site        bool     // Set true if service is a site (Example: Network gateway)
 }
 
 


### PR DESCRIPTION
resolves https://github.com/jsirianni/gocron/issues/50

POST requests are now supported. Curl example:
```
 curl -v -X POST \
-d "{\"cronname\":\"test\",\"account\":\"test account\", \"email\":\"test@gmail.com\",\"frequency\":20}" \
http://10.0.2.15:8080
```
Server response
```
Parameters from 10.0.2.15 passed validation
Heartbeat from test: test account 
```